### PR TITLE
Fix loading custom table definitions and support tupledef revisions

### DIFF
--- a/src/WixToolset.Data/SimpleTupleDefinitionCreator.cs
+++ b/src/WixToolset.Data/SimpleTupleDefinitionCreator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
+// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
 
 namespace WixToolset.Data
 {
@@ -10,7 +10,10 @@ namespace WixToolset.Data
 
         public void AddCustomTupleDefinition(IntermediateTupleDefinition definition)
         {
-            this.CustomDefinitionByName.Add(definition.Name, definition);
+            if (!this.CustomDefinitionByName.TryGetValue(definition.Name, out var existing) || definition.Revision > existing.Revision)
+            {
+                this.CustomDefinitionByName[definition.Name] = definition;
+            }
         }
 
         public bool TryGetTupleDefinitionByName(string name, out IntermediateTupleDefinition tupleDefinition)

--- a/src/test/WixToolsetTest.Data/SerializeFixture.cs
+++ b/src/test/WixToolsetTest.Data/SerializeFixture.cs
@@ -42,6 +42,130 @@ namespace WixToolsetTest.Data
         }
 
         [Fact]
+        public void CanSaveAndLoadIntermediateWithCustomDefinitions()
+        {
+            var sln = new SourceLineNumber("test.wxs", 1);
+
+            var section = new IntermediateSection("test", SectionType.Product, 65001);
+
+            var fieldDefs = new[]
+            {
+                new IntermediateFieldDefinition("A", IntermediateFieldType.String),
+                new IntermediateFieldDefinition("B", IntermediateFieldType.Number),
+                new IntermediateFieldDefinition("C", IntermediateFieldType.Bool),
+            };
+
+            var tupleDef = new IntermediateTupleDefinition("CustomDef", fieldDefs, null);
+
+            var tuple = tupleDef.CreateTuple(sln, new Identifier(AccessModifier.Public, "customT"));
+            tuple.Set(0, "foo");
+            tuple.Set(1, 2);
+            tuple.Set(2, true);
+
+            section.Tuples.Add(tuple);
+
+            var intermediate = new Intermediate("TestIntermediate", new[] { section }, null, null);
+
+            var path = Path.GetTempFileName();
+            try
+            {
+                intermediate.Save(path);
+
+                var loaded = Intermediate.Load(path);
+                var loadedSection = loaded.Sections.Single();
+                var loadedTuple = loadedSection.Tuples.Single();
+
+                Assert.Equal("foo", loadedTuple.AsString(0));
+                Assert.Equal(2, loadedTuple[1].AsNumber());
+                Assert.True(loadedTuple[2].AsBool());
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        [Fact]
+        public void CanSaveAndLoadMultipleIntermediateWithCustomDefinitions()
+        {
+            var sln = new SourceLineNumber("test.wxs", 1);
+
+            // Intermediate #1
+            var fieldDefs = new[]
+            {
+                new IntermediateFieldDefinition("A", IntermediateFieldType.String),
+                new IntermediateFieldDefinition("B", IntermediateFieldType.Number),
+                new IntermediateFieldDefinition("C", IntermediateFieldType.Bool),
+            };
+
+            var tupleDef = new IntermediateTupleDefinition("CustomDef", fieldDefs, null);
+
+            var tuple = tupleDef.CreateTuple(sln, new Identifier(AccessModifier.Public, "customT"));
+            tuple.Set(0, "foo");
+            tuple.Set(1, 2);
+            tuple.Set(2, true);
+
+            var section = new IntermediateSection("test", SectionType.Product, 65001);
+            section.Tuples.Add(tuple);
+
+            var intermediate1 = new Intermediate("TestIntermediate", new[] { section }, null, null);
+
+            // Intermediate #2
+            var fieldDefs2 = new[]
+            {
+                new IntermediateFieldDefinition("A", IntermediateFieldType.String),
+                new IntermediateFieldDefinition("B", IntermediateFieldType.Number),
+                new IntermediateFieldDefinition("C", IntermediateFieldType.Bool),
+                new IntermediateFieldDefinition("D", IntermediateFieldType.String),
+            };
+
+            var tupleDef2 = new IntermediateTupleDefinition("CustomDef", 1, fieldDefs2, null);
+
+            var tuple2 = tupleDef2.CreateTuple(sln, new Identifier(AccessModifier.Public, "customT2"));
+            tuple2.Set(0, "bar");
+            tuple2.Set(1, 3);
+            tuple2.Set(2, false);
+            tuple2.Set(3, "baz");
+
+            var section2 = new IntermediateSection("test2", SectionType.Fragment, 65001);
+            section2.Tuples.Add(tuple2);
+
+            var intermediate2 = new Intermediate("TestIntermediate2", new[] { section2 }, null, null);
+
+            // Save
+            var path1 = Path.GetTempFileName();
+            var path2 = Path.GetTempFileName();
+            try
+            {
+                intermediate1.Save(path1);
+                intermediate2.Save(path2);
+
+                var loaded = Intermediate.Load(new[] { path1, path2 });
+
+                var loaded1 = loaded.First();
+                var loaded2 = loaded.Skip(1).Single();
+
+                var loadedTuple1 = loaded1.Sections.Single().Tuples.Single();
+                var loadedTuple2 = loaded2.Sections.Single().Tuples.Single();
+
+                Assert.Equal("foo", loadedTuple1.AsString(0));
+                Assert.Equal(2, loadedTuple1[1].AsNumber());
+                Assert.True(loadedTuple1[2].AsBool());
+                Assert.Null(loadedTuple1.AsString(3));
+
+                Assert.Equal("bar", loadedTuple2.AsString(0));
+                Assert.Equal(3, loadedTuple2[1].AsNumber());
+                Assert.False(loadedTuple2[2].AsBool());
+                Assert.Equal("baz", loadedTuple2.AsString(3));
+            }
+            finally
+            {
+                File.Delete(path2);
+                File.Delete(path1);
+            }
+        }
+
+        [Fact]
         public void CanSaveAndLoadIntermediateWithLocalization()
         {
             var sln = new SourceLineNumber("test.wxs", 10);


### PR DESCRIPTION
Loading multiple intermediates with the same custom table definition
would crash when trying to redefine the definition. Now definitions
contain a revision and the highest tuple definition is used when
loading multiple intermediates.